### PR TITLE
tab and enter handling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,60 +1,30 @@
 <template>
     <div id="app" class="mt-2">
-        <vue-single-select      
-            v-model="thread" 
-            :options="threads"
-            :required="true"
-            option-label="a_title"
-            :getOptionDescription="getCustomDescription"
-            option-key="id"
-            name="dude"
-        ></vue-single-select>    
-        <form class="p-2 form w-full bg-x" style="xbackground: yellow" @submit.prevent>
-            <div class="mt-1">
-            <label>foo</label>
-            <input class="search-input inline-block" value="roob">
-            </div>
-            <div v-if="false" class="m-1 p-1" style="width: 50%">
-                <label class="mr-1 inline">select</label>
-                <vue-taggable-select v-on:option-created="addOption"
-                    v-model="fruit" 
-                    :options="fruits"
-                    :taggable="true"
-                ></vue-taggable-select>
-                <hr>
-                {{fruits}}
-                {{fruit}}
-                <br><hr class="mb-4">
-                <vue-taggable-select v-false="true"
-                                  v-model="myThreads"
-                                  :options="threads"
-                                  optionLabel="a_title"
-                                  :max-results="10"
-                >
-
-                </vue-taggable-select>
-            </div>
-            <div v-show="false" class="w-50">
-                <hr>
-                {{nums}}
-                {{numbers}}
-                <br><hr class="mb-4">
-                <vue-taggable-select
-                                  v-model="nums"
-                                  :options="numbers"
-                                  :max-results="4"
-                >
-
-                </vue-taggable-select>
-            </div>
+        <form class="p-2 form w-full bg-x" style="xbackground: yellow" >
+            <vue-single-select      
+                v-model="thread" 
+                :options="threads"
+                :required="true"
+                option-label="a_title"
+                :getOptionDescription="getCustomDescription"
+                option-key="id"
+                name="dude"
+            ></vue-single-select>    
+                <div class="mt-1">
+                <label>foo</label>
+                <input class="search-input inline-block" value="roob">
+                </div>
+            <select class="form-control" name="rob">
+                <option>red</option>
+                <option>blue</option>
+                <option>green</option>
+                <option>yellow</option>
+             </select>
+             <label>bar</label>
+             <input class="search-input inline-block" value="rab">
         </form>
         <hr>
-        <!-- select class="form-control" name="rob">
-             <option>red</option>
-             <option>red</option>
-             <option>red</option>
-             <option>red</option>
-             </select -->
+        <!--  -->
         <button type="button" class="button py-2 px-4 bg-grey-lighter border rounded mt-2" >button</button>
         <hr>
     </div>

--- a/src/VueSingleSelect.vue
+++ b/src/VueSingleSelect.vue
@@ -7,11 +7,11 @@
                        :id="inputId"
                        @click="seedSearchText"
                        @focus="seedSearchText"
-                       @keyup.enter="setOption"
-                       @keyup.down="movePointerDown"
-                       @keyup.tab.stop="closeOut"
+                       @keydown.enter.stop="setOption"
+                       @keydown.tab="setOption"
                        @keyup.esc.stop="closeOut"
                        @keyup.up="movePointerUp"
+                       @keyup.down="movePointerDown"
                        :placeholder="placeholder"
                        autocomplete="off"
                        :required="required"
@@ -37,10 +37,9 @@
                         class="cursor-pointer outline-none"
                         @blur="handleClickOutside($event)"
                         @mouseover="setPointerIdx(idx)"
-                        @keyup.enter="setOption()"
                         @keyup.up="movePointerUp()"
                         @keyup.down="movePointerDown()"
-                        @click.prevent="setOption()"
+                        @click.prevent="setOption"
                     >
                         <slot name="option" v-bind="{option,idx}">
                             {{ getOptionDescription(option) }}
@@ -333,7 +332,7 @@ export default {
                  this.pointer--;
              }
          },
-         setOption() {
+         setOption(e) {
              if (!this.matchingOptions || !this.matchingOptions.length) {
                  return;
              }
@@ -345,9 +344,11 @@ export default {
              this.searchText = null;
              this.dropdownOpen = false;
              this.pointer = -1;
-             this.$nextTick().then(() => {
-                 this.$refs.match.focus();
-             });
+             if(!(e && e.code && e.code === 'Tab')) {
+                this.$nextTick().then(() => {
+                    this.$refs.match.focus();
+                });
+             }
          },
          handleClickOutside(e) {
              if (this.$el.contains(e.target)) {


### PR DESCRIPTION
changes were made to meet my needs, and as much as anything this is to let you know some things I found - whether you take or leave any of this pull request is obviously up to you.

**Changes to VueSingleSelect.vue**
1. Stop propagation on enter - many developers will have their inputs inside a form, and will not want the form to be submitted on enter. therfore needs to be keydown with stop
2. the key.enter event over the li could not be fired in any browsers I tested.
3. Tab should select an element to my mind
4 this is purely behaviour I like but tab now selects and also tabs to the next element. this is not the default behavior of all native selects, so take it or leave it (line 347).

note 2 tests are failing but I don't think it is my changes.

Changes to App.vue
1. 3 references to vue-taggable-select, which is (appropriately) no longer imported (resulting in a console error)
2. a native select was included to allow you/others to compare the native behaviour to esc, enter, tab etc
